### PR TITLE
Reduce permissions on Image Gallery for jenkins mi's

### DIFF
--- a/components/jenkins/shared_image_gallery.tf
+++ b/components/jenkins/shared_image_gallery.tf
@@ -6,6 +6,6 @@ data "azurerm_shared_image_gallery" "imagegallery" {
 resource "azurerm_role_assignment" "imagegallery" {
   provider             = azurerm.image_gallery
   scope                = data.azurerm_shared_image_gallery.imagegallery.id
-  role_definition_name = "Contributor"
+  role_definition_name = "Reader"
   principal_id         = azurerm_user_assigned_identity.usermi.principal_id
 }


### PR DESCRIPTION
### Change description ###
I noticed that jenkins-ptl-mi has only had "Reader" permissions on the image gallery so I'm assuming it doesn't need contributor or does it?


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
