### PR TITLE
DTSPO-9049 - Revert to devops library master branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ resources:
   repositories:
   - repository: cnp-azuredevops-libraries
     type: github
-    ref: DTSPO-2880_sds_ptl
+    ref: master
     name: hmcts/cnp-azuredevops-libraries
     endpoint: 'hmcts (1)'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DSTPO-9049


### Change description ###
Revert to using master branch of cnp-azuredevops-libraries


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
