### PR TITLE
DTSPO-14754 - Reduce max_delivery_count to 20

### DIFF
--- a/components/jenkins/integration.tf
+++ b/components/jenkins/integration.tf
@@ -15,7 +15,7 @@ module "jenkins-webhook-relay" {
   zone_redundant                     = var.zone_redundant
   enable_workflow                    = var.enable_workflow
   common_tags                        = module.tags.common_tags
-  max_delivery_count                 = 50
+  max_delivery_count                 = 20
 }
 
 resource "azurerm_key_vault_secret" "logicappsecret" {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14754

### Change description ###
Reducing max delivery count to 20
Sonar scan deliveries that get stuck in an error state should be further reduced

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
