### PR TITLE
DTSPO-15318: Add role assignment for app-proxy service connection

### DIFF
--- a/components/jenkins/data.tf
+++ b/components/jenkins/data.tf
@@ -16,3 +16,7 @@ data "azurerm_resource_group" "acr_rg" {
   provider = azurerm.acr
   name     = "rpe-acr-prod-rg"
 }
+
+data "azuread_service_principal" "app_proxy_ga_service_connection" {
+  display_name = "DTS Operations Bootstrap GA"
+}

--- a/components/jenkins/keyvault.tf
+++ b/components/jenkins/keyvault.tf
@@ -20,7 +20,7 @@ resource "azurerm_role_assignment" "jenkinskvrole" {
 resource "azurerm_role_assignment" "app-proxy-ga-service-connection-secret-management" {
   scope                = azurerm_key_vault.jenkinskv.id
   role_definition_name = "Key Vault Secrets Officer"
-  principal_id         = data.azuread_service_principal.app_proxy_ga_service_connection
+  principal_id         = data.azuread_service_principal.app_proxy_ga_service_connection.principal_id
 }
 
 resource "azurerm_key_vault_secret" "disk" {

--- a/components/jenkins/keyvault.tf
+++ b/components/jenkins/keyvault.tf
@@ -20,7 +20,7 @@ resource "azurerm_role_assignment" "jenkinskvrole" {
 resource "azurerm_role_assignment" "app-proxy-ga-service-connection-secret-management" {
   scope                = azurerm_key_vault.jenkinskv.id
   role_definition_name = "Key Vault Secrets Officer"
-  principal_id         = data.azuread_service_principal.app_proxy_ga_service_connection.principal_id
+  principal_id         = data.azuread_service_principal.app_proxy_ga_service_connection.object_id
 }
 
 resource "azurerm_key_vault_secret" "disk" {

--- a/components/jenkins/keyvault.tf
+++ b/components/jenkins/keyvault.tf
@@ -16,6 +16,13 @@ resource "azurerm_role_assignment" "jenkinskvrole" {
   principal_id         = azurerm_user_assigned_identity.usermi.principal_id
 }
 
+# Allows app-proxy automation to add client secret to Jenkins Key Vault 
+resource "azurerm_role_assignment" "app-proxy-ga-service-connection-secret-management" {
+  scope                = azurerm_key_vault.jenkinskv.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azuread_service_principal.app_proxy_ga_service_connection
+}
+
 resource "azurerm_key_vault_secret" "disk" {
   name         = "jenkins-disk-id"
   value        = azurerm_managed_disk.disk.id


### PR DESCRIPTION
[DTSPO-15318](https://tools.hmcts.net/jira/browse/DTSPO-15318)

Issue spotted during SDS Jenkins migration to app proxy - these key vaults are RBAC only for starters, so need a role adding instead of access policy.

In [app-proxy automation](https://github.com/hmcts/azure-app-proxy/blob/main/azure-pipelines.yaml#L97) when a new app is added, the generated client secret is added to a specified vault. To do this, it's service connection `
DTS Operations Bootstrap GA` needs permission to set secrets in the vaults. I added this manually during migration but backfilling in code in this PR

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
