### PR TITLE
Revert "Update Terraform azuread to v3.9.0"

### DIFF
--- a/components/jenkins-agent-identities/init.tf
+++ b/components/jenkins-agent-identities/init.tf
@@ -6,7 +6,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "3.9.0"
+      version = "3.8.0"
     }
   }
 


### PR DESCRIPTION
Reverts hmcts/sds-jenkins-infrastructure#120

Getting an error in the pipeline:
```
with data.azuread_group.directory_readers,
│   on data.tf line 1, in data "azuread_group" "directory_readers":
│    1: data "azuread_group" "directory_readers" {
invalid character '{' after object key:value pair
```